### PR TITLE
Add --to-size option on simplify command

### DIFF
--- a/src/geoq/commands/measure.rs
+++ b/src/geoq/commands/measure.rs
@@ -66,7 +66,7 @@ fn coords(matches: &ArgMatches) -> Result<(), Error> {
 pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     match matches.subcommand() {
         ("distance", Some(m)) => distance(m),
-        ("coords", Some(m)) => coords(m),
+        ("coord-count", Some(m)) => coords(m),
         _ => Err(Error::UnknownCommand),
     }
 }

--- a/src/geoq/text.rs
+++ b/src/geoq/text.rs
@@ -153,10 +153,22 @@ Uses the Visvalingham-Whyatt topology-preserving simplification algorithm.
 Only (Multi-)LineStrings and (Multi-)Polygons will be affected.
 
 Takes Epsilon as a command-line parameter
+
+If the optional --to-size arg is given, geoq will iteratively simplify each
+given geometry until it is under this target number of vertices, starting
+from the provided epsilon and doubling on each attempt.
+
+The iterative simplification will stop after 20 attempts, so it's still
+good to check the coord-count of each geometry afterward to determine
+if any rows were unable to be simplified under the desired threshold.
 ";
 
 pub const SIMPLIFY_EPSILON_ARG_HELP: &str = r"
 Simplification epsilon as float, e.g 0.001.
+";
+
+pub const SIMPLIFY_TO_COORD_COUNT_ARG_HELP: &str = r"
+Target number of coords to simplify to.
 ";
 
 pub const MEASURE_COORDS_ABOUT: &str =

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ fn main() {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("coords")
+            SubCommand::with_name("coord-count")
                 .about(text::MEASURE_COORDS_ABOUT)
                 .arg(
                     Arg::with_name("geojson")
@@ -150,6 +150,12 @@ fn main() {
                 .help(text::SIMPLIFY_EPSILON_ARG_HELP)
                 .required(true)
                 .index(1),
+        ).arg(
+            Arg::with_name("to_coord_count")
+                .long("to-coord-count")
+                .required(false)
+                .takes_value(true)
+                .help(text::SIMPLIFY_TO_COORD_COUNT_ARG_HELP),
         );
 
     let snip = SubCommand::with_name("snip")


### PR DESCRIPTION
Enables simplifying geometries until they're under a given coordinate threshold.