### PR TITLE
Add json "munge" command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 rust:
-  - stable
-  - beta
   - nightly
 matrix:
   fast_finish: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "geoq"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "assert_cli",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geoq"
-version = "0.0.16"
+version = "0.0.17"
 authors = ["Horace Williams <horace@worace.works>"]
 license = "MIT"
 description = "Geospatial utility CLI"

--- a/src/geoq/commands/json.rs
+++ b/src/geoq/commands/json.rs
@@ -1,22 +1,93 @@
 use crate::geoq::error::Error;
+use geo_types::{Geometry, Point};
 use clap::ArgMatches;
 use serde_json::{json, Map, Number, Value};
 use std::io::{self, BufRead};
 
-pub fn find_number(v: &Map<String, Value>, keys: &Vec<&str>) -> Option<Number> {
+pub fn find_number(v: &Map<String, Value>, keys: &Vec<&'static str>) -> Option<(&'static str, f64)> {
     for k in keys {
         if !v.contains_key(*k) {
             continue;
         }
         match v[*k] {
-            Value::Number(ref n) => return Some(n.clone()),
+            Value::Number(ref n) => return n.as_f64().map(|f| (*k, f)),
             _ => continue,
         }
     }
     None
 }
 
-fn point() -> Result<(), Error> {
+type Geom = Geometry<f64>;
+
+fn latlon_point(v: &Map<String, Value>) -> Option<(Geom, Vec<String>)> {
+    let lat = find_number(&v, &vec!["latitude", "lat"]);
+    let lon = find_number(&v, &vec!["longitude", "lon", "lng"]);
+    let lat_lon: Option<_> = try { (lat?, lon?) };
+    lat_lon.map(|((lat_key, lat), (lon_key, lon))| (Geometry::Point(Point::new(lon, lat)), vec![lat_key.to_string(), lon_key.to_string()]))
+}
+
+fn wkt_geom(v: &Map<String, Value>) -> Option<(Geom, Vec<String>)> {
+    let geom_opt = v.get("geometry").map(|s| ("geometry", s));
+    let wkt_opt = v.get("wkt").map(|s|("wkt", s));
+    let str_opt = geom_opt.or(wkt_opt);
+    str_opt.and_then(|(k, v)| v.as_str().map(|v| (k, v)))
+        .and_then(|(k, v)| wkt::Wkt::from_str(v).ok().map(|wkt| (k, wkt)))
+        .and_then(|(k,wkt)| {
+            if (wkt.items.is_empty()) {
+                None
+            } else {
+                wkt::conversion::try_into_geometry(&wkt.items[0]).ok().map(|geom| (geom, vec![k.to_string()]))
+            }
+        })
+}
+
+pub fn find_geometry(v: &Map<String, Value>) -> Option<(Geom, Vec<String>)> {
+    latlon_point(v).or(wkt_geom(v))
+    // latlon_point
+    // Point
+    // - lat/lon
+    // - lat/lng
+    // - latitude/longitude
+    // Geometry
+    // - wkt
+    // - geometry: geojson string
+    // - geometry: geojson geometry
+    // None
+}
+
+// fn point() -> Result<(), Error> {
+//     let stdin = io::stdin();
+//     for l in stdin.lock().lines() {
+//         let line = l?;
+//         let v: Value = serde_json::from_str(&line)?;
+//         match v {
+//             Value::Object(o) => {
+//                 match (
+//                     find_number(&o, &vec!["latitude", "lat"]),
+//                     find_number(&o, &vec!["longitude", "lon", "lng"]),
+//                 ) {
+//                     (Some(lat), Some(lon)) => {
+//                         let geojson = json!({
+//                             "type": "Feature",
+//                             "properties": Value::Object(o),
+//                             "geometry": {
+//                                 "type": "Point",
+//                                 "coordinates": vec![Value::Number(lon), Value::Number(lat)]
+//                             }
+//                         });
+//                         let json_str = serde_json::to_string(&geojson)?;
+//                         println!("{}", json_str)
+//                     }
+//                     _ => return Err(Error::InvalidJSONType),
+//                 }
+//             }
+//             _ => return Err(Error::InvalidJSONType),
+//         }
+//     }
+//     Ok(())
+// }
+
+fn munge() -> Result<(), Error> {
     let stdin = io::stdin();
     for l in stdin.lock().lines() {
         let line = l?;
@@ -32,8 +103,7 @@ fn point() -> Result<(), Error> {
                             "type": "Feature",
                             "properties": Value::Object(o),
                             "geometry": {
-                                "type": "Point",
-                                "coordinates": vec![Value::Number(lon), Value::Number(lat)]
+                                "type": "Point"
                             }
                         });
                         let json_str = serde_json::to_string(&geojson)?;
@@ -50,7 +120,8 @@ fn point() -> Result<(), Error> {
 
 pub fn run(m: &ArgMatches) -> Result<(), Error> {
     match m.subcommand() {
-        ("point", Some(_)) => point(),
+        // ("point", Some(_)) => point(),
+        ("munge", Some(_)) => munge(),
         _ => Err(Error::UnknownCommand),
     }
 }

--- a/src/geoq/commands/json.rs
+++ b/src/geoq/commands/json.rs
@@ -3,7 +3,7 @@ use geo_types::{Geometry, Point};
 use geojson::GeoJson;
 use clap::ArgMatches;
 use serde_json;
-use serde_json::{json, Map, Number, Value};
+use serde_json::{json, Map, Value};
 use std::{convert::TryInto};
 use std::io::{self, BufRead};
 
@@ -59,7 +59,7 @@ fn wkt_geom(v: &Map<String, Value>) -> Option<(Geom, Vec<String>)> {
     let str_opt_with_key = find_string(v, &vec!["geometry", "wkt"]);
     str_opt_with_key.and_then(|(k, v)| wkt::Wkt::from_str(&v).ok().map(|wkt| (k, wkt)))
         .and_then(|(k,wkt)| {
-            if (wkt.items.is_empty()) {
+            if wkt.items.is_empty() {
                 None
             } else {
                 // TODO what to do with multiple wkt geoms

--- a/src/geoq/text.rs
+++ b/src/geoq/text.rs
@@ -1,17 +1,20 @@
-pub const JSON_POINT_AFTER_HELP: &str = r#"
-Create a GeoJSON Point from arbitrary JSON by searching for common
-latitude and longitude property names.
+pub const JSON_MUNGE_AFTER_HELP: &str = r#"
+Create a GeoJSON Feature from arbitrary JSON by checking some common
+patterns used for embedding geo data in JSON objects.
 
-Latitude keys are 'latitude' and 'lat'.
-Longitude keys are 'longitude', 'lon', and 'lng'.
+The checks include:
 
-The original JSON object will be embedded in the GeoJSON 'properties' key.
+* latitude and longitude under the lat, latitude, lon, longitude, or lng keys
+* WKT strings under the geometry or wkt keys
+* GeoJSON geometries as strings under the geometry or geojson keys
+* GeoJSON geometries as objects under the geometry or geojson keys
+
+The original JSON object, minus the matched geometry keys, will be embedded in the GeoJSON 'properties' key.
 
 Example:
 
-$ echo '{"latitude":12.0,"longitude":34.0,"key":"val"}' | geoq json point
-  {"geometry":{"coordinates":[34.0,12.0],"type":"Point"},
-   "properties":{"key":"val","latitude":12.0,"longitude":34.0},"type":"Feature"}
+$ echo '{"latitude":12.0,"longitude":34.0,"key":"val"}' | geoq json munge
+{"geometry":{"coordinates":[34.0,12.0],"type":"Point"}, "properties":{"key":"val"},"type":"Feature"}
 "#;
 
 pub const READ_AFTER_HELP: &str = r#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,9 @@ fn main() {
     let json = SubCommand::with_name("json")
         .about("Best-guess conversions from geo-oriented JSON to GeoJSON")
         .subcommand(
-            SubCommand::with_name("point")
-                .about("Attempt to convert arbitrary JSON to a GeoJSON Point.")
-                .after_help(text::JSON_POINT_AFTER_HELP),
+            SubCommand::with_name("munge")
+                .about("Attempt to convert arbitrary JSON to a GeoJSON Feature.")
+                .after_help(text::JSON_MUNGE_AFTER_HELP),
         );
 
     let read = SubCommand::with_name("read")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(try_blocks)]
 mod geoq;
 use geoq::commands;
 use geoq::error::Error;

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -573,26 +573,28 @@ fn reading_geojson_feature_without_properties() {
 }
 
 #[test]
-fn json_point() {
+fn json_munge() {
     let input = r#"{"latitude": 34.3, "longitude": -118.2, "name": "Horace", "pizza": "pie"}
 {"lat": 34.3, "lon": -118.2, "name": "Horace", "pizza": "pie"}
 {"latitude": 34.3, "lng": -118.2, "name": "Horace", "pizza": "pie"}
+{"name": "Horace", "pizza": "pie", "wkt":"POINT(-118.3991 33.9924)"}
 "#;
 
-    let output = r#"{"geometry":{"coordinates":[-118.2,34.3],"type":"Point"},"properties":{"latitude":34.3,"longitude":-118.2,"name":"Horace","pizza":"pie"},"type":"Feature"}
-{"geometry":{"coordinates":[-118.2,34.3],"type":"Point"},"properties":{"lat":34.3,"lon":-118.2,"name":"Horace","pizza":"pie"},"type":"Feature"}
-{"geometry":{"coordinates":[-118.2,34.3],"type":"Point"},"properties":{"latitude":34.3,"lng":-118.2,"name":"Horace","pizza":"pie"},"type":"Feature"}
+    let output = r#"{"geometry":{"coordinates":[-118.2,34.3],"type":"Point"},"properties":{"name":"Horace","pizza":"pie"},"type":"Feature"}
+{"geometry":{"coordinates":[-118.2,34.3],"type":"Point"},"properties":{"name":"Horace","pizza":"pie"},"type":"Feature"}
+{"geometry":{"coordinates":[-118.2,34.3],"type":"Point"},"properties":{"name":"Horace","pizza":"pie"},"type":"Feature"}
+{"geometry":{"coordinates":[-118.3991,33.9924],"type":"Point"},"properties":{"name":"Horace","pizza":"pie"},"type":"Feature"}
 "#;
 
     Assert::main_binary()
-        .with_args(&["json", "point"])
+        .with_args(&["json", "munge"])
         .stdin(input)
         .stdout()
         .is(output)
         .unwrap();
 
     Assert::main_binary()
-        .with_args(&["json", "point"])
+        .with_args(&["json", "munge"])
         .stdin("pizza")
         .fails()
         .unwrap();


### PR DESCRIPTION
This will attempt to convert a "geo-flavored" JSON object into a GeoJSON feature. Geo-flavored JSON is JSON that encoded geometry info in a custom way, such as putting in `latitude` and `longitude` keys, embedding a WKT string in a key like `wkt` or `geometry`, etc.